### PR TITLE
test: explicitely count line number rows instead of trying to match on pretty confusing html

### DIFF
--- a/packages/gatsby-remark-prismjs/package.json
+++ b/packages/gatsby-remark-prismjs/package.json
@@ -15,6 +15,7 @@
     "@babel/cli": "^7.8.4",
     "@babel/core": "^7.8.7",
     "babel-preset-gatsby-package": "^0.3.1",
+    "cheerio": "^1.0.0-rc.3",
     "cross-env": "^5.2.1",
     "prismjs": "^1.19.0",
     "remark": "^9.0.0"

--- a/packages/gatsby-remark-prismjs/src/__tests__/__snapshots__/index.js.snap
+++ b/packages/gatsby-remark-prismjs/src/__tests__/__snapshots__/index.js.snap
@@ -588,52 +588,6 @@ color<span class=\\"token operator\\">:</span> red<span class=\\"token punctuati
 }
 `;
 
-exports[`remark prism plugin numberLines correctly counts line-numbers for markup using highlight classes 1`] = `
-Object {
-  "children": Array [
-    Object {
-      "lang": "js",
-      "position": Position {
-        "end": Object {
-          "column": 4,
-          "line": 7,
-          "offset": 108,
-        },
-        "indent": Array [
-          1,
-          1,
-          1,
-          1,
-          1,
-          1,
-        ],
-        "start": Object {
-          "column": 1,
-          "line": 1,
-          "offset": 0,
-        },
-      },
-      "type": "html",
-      "value": "<div class=\\"gatsby-highlight\\" data-language=\\"js\\"><pre style=\\"counter-reset: linenumber NaN\\" class=\\"language-js line-numbers\\"><code class=\\"language-js\\"><span class=\\"token keyword\\">function</span> <span class=\\"token function\\">highlightTest</span><span class=\\"token punctuation\\">(</span><span class=\\"token punctuation\\">)</span> <span class=\\"token punctuation\\">{</span>
-<span class=\\"gatsby-highlight-code-line\\"><span class=\\"token keyword\\">return</span> <span class=\\"token string\\">\\"this is a highlight test\\"</span></span><span class=\\"token punctuation\\">}</span></code><span aria-hidden=\\"true\\" class=\\"line-numbers-rows\\" style=\\"white-space: normal; width: auto; left: 0;\\"><span></span><span></span><span></span></span></pre></div>",
-    },
-  ],
-  "position": Object {
-    "end": Object {
-      "column": 4,
-      "line": 7,
-      "offset": 108,
-    },
-    "start": Object {
-      "column": 1,
-      "line": 1,
-      "offset": 0,
-    },
-  },
-  "type": "root",
-}
-`;
-
 exports[`remark prism plugin numberLines does not add line-number markup when not configured globally 1`] = `
 Object {
   "children": Array [

--- a/packages/gatsby-remark-prismjs/src/__tests__/add-line-numbers.js
+++ b/packages/gatsby-remark-prismjs/src/__tests__/add-line-numbers.js
@@ -1,4 +1,5 @@
 const addLineNumbers = require(`../add-line-numbers`)
+const cheerio = require(`cheerio`)
 
 describe(`returns the line numbers container`, () => {
   it(`should return the <span> container with the right classes`, () => {
@@ -23,10 +24,12 @@ describe(`returns the line numbers container`, () => {
       ` <span class=\\"gatsby-highlight-code-line\\"></span>` +
       ` line3\n` +
       `line4`
-    expect(addLineNumbers(highlightedCode)).toEqual(
-      `<span aria-hidden="true" class="line-numbers-rows" style="white-space: normal; width: auto; left: 0;">` +
-        `<span></span><span></span><span></span><span></span><span></span><span></span>` +
-        `</span>`
-    )
+
+    const highlightedCodeWithLineNumbers = addLineNumbers(highlightedCode)
+
+    const $ = cheerio.load(highlightedCodeWithLineNumbers)
+    const numberOfLineNumbers = $(`.line-numbers-rows > span`).length
+
+    expect(numberOfLineNumbers).toEqual(4 + 2)
   })
 })

--- a/packages/gatsby-remark-prismjs/src/__tests__/index.js
+++ b/packages/gatsby-remark-prismjs/src/__tests__/index.js
@@ -1,4 +1,5 @@
 const remark = require(`remark`)
+const cheerio = require(`cheerio`)
 let plugin
 
 describe(`remark prism plugin`, () => {
@@ -133,7 +134,11 @@ describe(`remark prism plugin`, () => {
         `\`\`\``
       const markdownAST = remark.parse(code)
       plugin({ markdownAST }, { showLineNumbers: true })
-      expect(markdownAST).toMatchSnapshot()
+
+      const htmlResult = markdownAST.children[0].value
+      const $ = cheerio.load(htmlResult)
+      const numberOfLineNumbers = $(`.line-numbers-rows > span`).length
+      expect(numberOfLineNumbers).toEqual(3)
     })
 
     it(`does not add line-number markup when not configured globally`, () => {


### PR DESCRIPTION
This is attempt at address my own comment in https://github.com/gatsbyjs/gatsby/pull/23031#issuecomment-614843102 (PR against PR :) )